### PR TITLE
40 search bar and results width should match

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       <input style=""type="text" id="myInput" onkeyup="searchNames()" placeholder="Search for names..">
     </th>
   </tr>
-  <tr>
+  <tr class="radios">
     <th>
       <div id="pagination" class="pagination">
         <button id="prev" class="paginate-btn">Previous</button>

--- a/main.css
+++ b/main.css
@@ -6,6 +6,15 @@
     color:#f29999
   }
 
+  table {
+    width: 75%
+  }
+
+  .radios {
+    justify-content: left;
+    display: flex;
+  }
+
   #th1 {
     padding-left: 0px;
     padding-right: 8px;
@@ -76,6 +85,12 @@
     background-color:#a04242;
     color:#f29999
   }
+
+  .pagination {
+    justify-content: left;
+    display: flex;
+  }
+
   h1 {
     font-size: 46px;
   }

--- a/main.css
+++ b/main.css
@@ -6,15 +6,6 @@
     color:#f29999
   }
 
-  table {
-    width: 75%
-  }
-
-  .radios {
-    justify-content: left;
-    display: flex;
-  }
-
   #th1 {
     padding-left: 0px;
     padding-right: 8px;
@@ -76,6 +67,18 @@
       max-width: 500px;
       margin: auto;
     }
+
+/* --- Desktop view --- */
+@media screen and (min-width: 768px) {
+  table {
+    width: 75%;
+  }
+
+  .radios {
+    justify-content: left;
+    display: flex;
+  }
+}
 
 /* --- Mobile view --- */
 @media screen and (max-width: 768px) {

--- a/main.css
+++ b/main.css
@@ -21,7 +21,7 @@
     max-width: 500px;
     margin: auto;
   }
-  
+
   #myInput {
     width: 100%;
     /*background-image: url('/css/searchicon.png'); /* Add a search icon to input */
@@ -34,7 +34,7 @@
     /*margin-bottom: 12px; /* Add some space below the input */
     /*width: 500px;*/
   }
-  
+
   #nameList {
     /* Remove default list styling */
     padding: 0;
@@ -87,11 +87,6 @@
     /*color:*/
     background-color:#a04242;
     color:#f29999
-  }
-
-  .pagination {
-    justify-content: left;
-    display: flex;
   }
 
   h1 {


### PR DESCRIPTION
This makes the search bar the same width as the table content. It also aligns the radio buttons to the left, and fixes reactive alignment in mobile views.

Original Issue: https://github.com/users/source-butcher/projects/1/views/1?pane=issue&itemId=143327443&issue=source-butcher%7Cbutche.red%7C40

BEFORE:
<img width="480" height="679" alt="Screenshot 2025-12-05 at 8 44 51 AM" src="https://github.com/user-attachments/assets/2db452a9-94bf-4f4d-910e-21b29f352d50" />
<img width="480" height="679" alt="Screenshot 2025-12-05 at 8 45 19 AM" src="https://github.com/user-attachments/assets/20137629-d731-47b8-a46b-520439bc7003" />

AFTER:
<img width="480" height="655" alt="Screenshot 2025-12-05 at 8 44 04 AM" src="https://github.com/user-attachments/assets/717f2132-683e-4208-ae2d-dcd3c41c7640" />
<img width="480" height="679" alt="Screenshot 2025-12-05 at 8 44 25 AM" src="https://github.com/user-attachments/assets/85ecf5a9-76b7-49ec-8810-b35a2ebfe79a" />

